### PR TITLE
Replace smart quotes with ASCII quotes to fix category parsing issues

### DIFF
--- a/content/members/Albin_Michel.md
+++ b/content/members/Albin_Michel.md
@@ -1,13 +1,13 @@
 ---
 title: Albin Michel
 member_url: https://www.albin-michel.fr/
-geographies: [“Worldwide”]
-based: [“France”]
+geographies: ["Worldwide"]
+based: ["France"]
 ig: ["LCP"] 
 services: 
 tags: []
-categories: [“Publishing“]
-summary: “The Albin Michel group is made up of Editions Albin Michel, Magnard-Vuibert, Editions Leduc, Jouvence, La Bibliothèque des écoles, E-Dantès, Dilisco, the recently acquired Humensis group (Belin, PUF, Que sais-je, éditions de l'Observatoire, éditions des Equateurs) and seven bookstores.”
+categories: ["Publishing"]
+summary: "The Albin Michel group is made up of Editions Albin Michel, Magnard-Vuibert, Editions Leduc, Jouvence, La Bibliothèque des écoles, E-Dantès, Dilisco, the recently acquired Humensis group (Belin, PUF, Que sais-je, éditions de l'Observatoire, éditions des Equateurs) and seven bookstores."
 active: true
 layout: members
 showReadTime: false

--- a/content/members/Beat.md
+++ b/content/members/Beat.md
@@ -1,13 +1,13 @@
 ---
 title: Beat Technology AS
 member_url: https://beat.no
-geographies: [“Worldwide”]
-based: [“Norway”]
+geographies: ["Worldwide"]
+based: ["Norway"]
 ig: ["LCP"] 
 services: 
 tags: []
-categories: [“Distribution“]
-summary: “Build, launch or integrate your audiobook and ebook offering with white-label apps, fulfilment tech, or standalone SDKs.”
+categories: ["Distribution"]
+summary: "Build, launch or integrate your audiobook and ebook offering with white-label apps, fulfilment tech, or standalone SDKs."
 active: true
 layout: members
 showReadTime: false

--- a/content/members/EBSCO.md
+++ b/content/members/EBSCO.md
@@ -7,7 +7,7 @@ ig: ["LCP"]
 crossroads:
 services: 
 tags: [""]
-categories: ["Distribution", “technology providers] 
+categories: ["Distribution", "technology providers"]
 summary: "EBSCO is a leading provider of research databases, e-journal and e-package subscription management, book collection development and acquisition management, and a major provider of library technology, e-books and clinical decision solutions for universities, colleges, hospitals, corporations, government, K12 schools and public libraries worldwide"
 press:
 active: true


### PR DESCRIPTION
Some member records use typographic (“smart”) quotes instead of standard ASCII quotes in category definitions.

Currently, clicking "Distribution" or "Publishing" on [the members page](https://members.edrlab.org/members/) does not work properly. Hopefully, this fix does the trick.